### PR TITLE
Update minimum python version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the beginnings of a roguelike, set in the [Flora](http://floraverse.com/
 
 You will need:
 
-* Python 3.3+
+* Python 3.4+
 * `urwid`
 * `zope.interface`
 


### PR DESCRIPTION
`geometry.py` uses `enum.Enum`, which was added in 3.4
